### PR TITLE
Generic SDP solvers for sosopt and gsosopt

### DIFF
--- a/gsosopt.m
+++ b/gsosopt.m
@@ -209,6 +209,7 @@ info.opts = opts;
 info.sosdata.obj = t;
 info.sosfeasfh = @(info,ttry) LOCALsosfeas(info,ttry,dbarprefix);
 info.tbnds = [];
+info.iter  = [];
 info = rmfield(info,'obj');
 
 
@@ -321,11 +322,9 @@ end
 %------------------------------------------------------------------
 % Perform Bisection
 %------------------------------------------------------------------
-go = 1;  % Ensure at least one pass through
+info.iter = 0;  % Ensure at least one pass through
 %while (tub-tlb>absbistol && tub-tlb>relbistol*tlb) || (go==1)
-while (tub-tlb>absbistol && tub-tlb>relbistol*abs(tlb)) || (go==1)
-    go = 0;
-    
+while (tub-tlb>absbistol && tub-tlb>relbistol*abs(tlb)) || ~info.iter
     % Set gamma level for feasibility problem
     ttry = (tub+tlb)/2;
     
@@ -359,6 +358,8 @@ while (tub-tlb>absbistol && tub-tlb>relbistol*abs(tlb)) || (go==1)
     else
         tlb = ttry;
     end
+    
+    info.iter = info.iter+1;
 end
 
 % Set output variable with upper/lower bounds
@@ -370,7 +371,7 @@ else
     info.tbnds = [tlb tub];    
 end
 info = orderfields(info,{'feas','tbnds','opts','sosdata','sos2sdp',...
-    'sdpdata','sdpsol','sosfeasfh'});
+    'sdpdata','sdpsol','sosfeasfh','iter'});
 
 return;
 
@@ -467,7 +468,7 @@ tinfo.sos2sdp.z = z;
 tinfo.sos2sdp.zremoved = zrem;
 tinfo.sos2sdp.dv2x = dv2x;
 % tinfo.sos2sdp.Nfv = Nfv;
-tinfo = orderfields(tinfo,{'feas','t','opts','sosdata','sos2sdp','sdpdata','sdpsol'});
+tinfo = orderfields(tinfo,{'feas','t','opts','sosdata','sos2sdp','sdpdata','sdpsol','iter'});
 
 % Exit if sossimplify detected infeasibility
 if feas

--- a/solvesossdp.m
+++ b/solvesossdp.m
@@ -48,38 +48,20 @@ solver = opts.solver;
 solveropts = opts.solveropts;
 
 % Solve SDP
-if strcmpi(solver,'dsdp')
-    [x,y,solverinfo] = sedumi2dsdp(A,b,c,K,solveropts);
-elseif strcmpi(solver,'csdp')
-    [x,y,solverinfo] = sedumi2csdp(A,b,c,K,solveropts);
-elseif strcmpi(solver,'sdpam')
-    [x,y,solverinfo] = sedumi2sdpam(A,b,c,K,solveropts);
-elseif strcmpi(solver,'sdplr')
-    [x,y,solverinfo] = sedumi2sdplr(A,b,c,K,solveropts);
-elseif strcmpi(solver,'sdpt3')
-    %     if length(c)<= length(b)
-    %         % 11/11/09 -- Ufuk found that sosopt(x^2) causes an error. This
-    %         % is because sedumi errors if length(c) <= length(b). Add dummy
-    %         % variables for now to catch this case.
-    %         Npad = length(b)-length(c)+1;
-    %         cpad = [c; zeros(Npad,1)];
-    %         Apad = [A  zeros(size(A,1),Npad)];
-    %         Kpad = K;
-    %         Kpad.s = [Kpad.s ones(1,Npad)];
-    %         [xpad,y,solverinfo] = sedumi2sdpt3(Apad,b,cpad,Kpad,solveropts);
-    %         x = xpad(1:end-Npad);
-    %     else
-    %         [x,y,solverinfo] = sedumi2sdpt3(A,b,c,K,solveropts);
-    %     end
+if exist(['sedumi2' solver], 'file')
+    % call requested solver if conversion from Sedumi is supported
     
     % XXX Sedumi allows for non-symmetric constraints, e.g. introduce
     % a 2-by-2 Q with a PSD constraint and then add an equality constraint
     % Q(1,2) = 4.  SDPT3 gives a warning and converts this to a
     % symmetric constraint.
-    [x,y,solverinfo] = sedumi2sdpt3(A,b,c,K,solveropts);
-elseif strcmpi(solver,'mosek')
-    [x,y,solverinfo] = sedumi2mosek(A,b,c,K,solveropts);
-elseif strcmpi(solver,'sedumi')
+    [x,y,solverinfo] = feval(['sedumi2' solver],A,b,c,K,solveropts);
+    return
+end
+
+% else:
+switch (solver)
+case 'sedumi'
     %if ~isfield(solveropts,'eps')
     %    solveropts.eps = 1e-9;
     %end
@@ -127,8 +109,12 @@ elseif strcmpi(solver,'sedumi')
         solverinfo.timing = 0;
         solverinfo.cpusec = 0;
     end
-elseif strcmpi(solver,'setup')
+    
+case 'setup'
     x=[]; y=[]; solverinfo=[];
-else
+    
+otherwise
     error(['Solver ' solver ' is not available']);
+end
+
 end

--- a/sosoptions.m
+++ b/sosoptions.m
@@ -76,9 +76,7 @@ classdef sosoptions
         % 'setup' is an undocumented call used by gsosopt
         function opt = set.solver(opt,value)
             % XXX Currently working: Sedumi, CSDP, SDPT3, SDPLR, Setup,
-            AllowableVal = {'sedumi'; 'sdpam'; 'csdp'; 'dsdp';...
-                'sdpt3';'sdplr'; 'mosek'; 'setup'};
-            if ischar(value) && any( strcmp(value,AllowableVal) )
+            if ischar(value)
                 opt.solver = value;
             else
                 errstr1 = 'solver can be ''sedumi'', ''sdpam'', ''csdp''';


### PR DESCRIPTION
This pull request allows the user to specify any possible SDP solver (not only those predefined in [`sosoptions`](https://github.com/SOSAnalysis/sosopt/blob/4820b34611089b05ad68f90a24fb914ec3195a71/sosoptions.m#L79-L80)) provided that a method

```
[x,y,solverinfo] = sedumi2SOLVER(A,b,c,K,solveropts);
```

exists and is accessible, where the `solver` options field is set to `'SOLVER'`.

This change gives experienced users the opportunity to use SDP solvers that are not yet "officially" supported (as in, there is a method `sedumi2SOLVER` included in sosopt).

On a minor note, with this pull request `gsosopt` returns the number of iterations (bisections) it performs in the `info` structure.